### PR TITLE
pymp4 cannot find the mdat box in a dfxp file, using regex to find and convert the content

### DIFF
--- a/subby/converters/mp4.py
+++ b/subby/converters/mp4.py
@@ -1,3 +1,5 @@
+import re
+
 from collections import deque
 
 from pymp4.parser import MP4
@@ -18,6 +20,11 @@ class ISMTConverter(BaseConverter):
         for box in MP4.parse(stream.read()):
             if box.type == b'mdat':
                 srt.extend(SMPTEConverter().from_bytes(box.data))
+        if not srt:
+            for mdat in re.compile(b'(\x00\x00..mdat.*?\x00\x00)', re.DOTALL).findall(stream.read()):
+                for box in MP4.parse(mdat):
+                    if box.type == b'mdat':
+                        srt.extend(SMPTEConverter().from_bytes(box.data))
 
         return srt
 


### PR DESCRIPTION
Bad dfxp file used to make this fix
[https://filebin.net/espe63pp1f41bv95/baddfxp.mp4](url)

