### PR TITLE
Add logic to replace double notes with single ones

### DIFF
--- a/subby/processors/common_issues.py
+++ b/subby/processors/common_issues.py
@@ -45,6 +45,8 @@ class CommonIssuesFixer(BaseProcessor):
             line = unicodedata.normalize('NFKC', line)
             # Replace short hyphen with regular size
             line = line.replace(r'‐', r'-')
+            # Replace double note with single note
+            line = line.replace(r'♫', r'♪')
             # Replace hashes, asterisks at the start of a line with a musical note
             line = re.sub(
                 r'^((?:{\\an8})?(?:<i>)?)(- ?)?[#\*]{1,}(?=\s+)',

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -55,7 +55,11 @@ ABCD FM
 
 13
 00:13:00,000 --> 00:13:01,000
-* Schnaub *'''
+* Schnaub *
+
+14
+00:14:00,000 --> 00:14:01,000
+♫ Thunder'''
 
 
 ADDING_LINE_BREAKS_EXAMPLE = '''1
@@ -150,6 +154,7 @@ def test_musical_notes():
     assert srt[10].content == '<i>♪ Fire ♪</i>'
     assert srt[11].content == '*Schnaub*'
     assert srt[12].content == '♪ Schnaub ♪'
+    assert srt[13].content == '♪ Thunder'
 
 
 # Test adding missing line breaks


### PR DESCRIPTION
Occasionally, .webvtt files will use double music notes, rather than the more common single notes to indicate music cues. This replaces these instances when fixing common issues.