### PR TITLE
Add logic to remove <v Name> tags from .webvtt

### DIFF
--- a/subby/converters/webvtt.py
+++ b/subby/converters/webvtt.py
@@ -17,7 +17,7 @@ STYLE_TAG_OPEN = re.compile(r'^<c.([a-zA-Z0-9]+)>([^<]+)')
 STYLE_TAG = re.compile(r'<c.([a-zA-Z0-9]+)>([^<]+)<\/c>')
 STYLE_TAG_CLOSE = re.compile(r'<\/c>$')
 SKIP_WORDS = ('WEBVTT', 'NOTE', '/*', 'X-TIMESTAMP-MAP')
-
+SPEAKER_TAG = re.compile(r'<v\s+[^>]+>')  # Matches opening <v Name> tags, closing tags handled by STYLE_TAG_CLOSE
 
 class WebVTTConverter(BaseConverter):
     """WebVTT subtitle converter"""
@@ -102,6 +102,9 @@ class WebVTTConverter(BaseConverter):
             elif looking_for_text:
                 # Unescape html entities
                 line = html.unescape(line)
+
+                # Remove speaker tags here
+                line = re.sub(SPEAKER_TAG, '', line)
 
                 # Set \an8 tag if position is below 25
                 # (value taken from SubtitleEdit)

--- a/tests/test_webvtt_conversion.py
+++ b/tests/test_webvtt_conversion.py
@@ -1,0 +1,19 @@
+from datetime import timedelta
+from io import BytesIO
+
+from subby import WebVTTConverter
+
+SPEAKER_TAG_TEST = b'''1
+00:00:01.000 --> 00:00:03.000
+- <v ID>TESTY TESTERSON:</v>
+<v Testerson>This is a test, if my name isn't Testy Testerson!</v>
+'''
+
+def test_speaker_tag_stripping():
+    converter = WebVTTConverter()
+    stream = BytesIO(SPEAKER_TAG_TEST)
+    srt = converter.parse(stream)
+
+    # Verify that speaker tag is stripped
+    assert len(srt) == 1
+    assert srt[0].content == "- TESTY TESTERSON:\nThis is a test, if my name isn't Testy Testerson!"


### PR DESCRIPTION
I have encountered .vtt files that include speaker information within `<v Name>` tags. The opening tags are not currently removed, but the closing ones are. Both should be removed during conversion.

```webvtt
00:00:15.431 --> 00:00:23:482
<v SFX>♪ <i>(syncopated percussion)</i></v>

00:00:23.982 --> 00:00:27.318
- <v Testerson>I've landed in the test environment
at quite an interesting time.</v>

00:00:27.318 --> 00:00:30.655
- <v ID>News anchor:</v>
<v Anchor>This is a test broadcast.</v>

00:00:30.822 --> 00:00:33.825
- <v Testerson>I just achieved two test results,
not even preliminary.</v>
```